### PR TITLE
Color fix

### DIFF
--- a/_static/css/cloudslang_theme.css
+++ b/_static/css/cloudslang_theme.css
@@ -1,8 +1,8 @@
 @import url("theme.css");
 
-.wy-side-nav-search{
-  background-color: #6DC692 !important;
-}
+.wy-nav-side .wy-side-nav-search{
+    background-color: #6DC692;
+  }
 
 .wy-side-nav-search input[type=text]{
   border-color: #6DC692 !important;

--- a/_static/css/cloudslang_theme.css
+++ b/_static/css/cloudslang_theme.css
@@ -1,9 +1,8 @@
 @import url("theme.css");
 
-.wy-nav-side .wy-side-nav-search{
+.wy-nav-side{
+  .wy-side-nav-search{
     background-color: #6DC692;
+    border-color: #6DC692;
   }
-
-.wy-side-nav-search input[type=text]{
-  border-color: #6DC692 !important;
 }

--- a/_static/css/cloudslang_theme.css
+++ b/_static/css/cloudslang_theme.css
@@ -1,8 +1,6 @@
 @import url("theme.css");
 
-.wy-nav-side{
-  .wy-side-nav-search{
+.wy-nav-side .wy-side-nav-search{
     background-color: #6DC692;
-    border-color: #6DC692;
-  }
+    border-color: #6DC692
 }

--- a/_static/css/cloudslang_theme.css
+++ b/_static/css/cloudslang_theme.css
@@ -1,9 +1,9 @@
 @import url("theme.css");
 
 .wy-side-nav-search{
-  background-color: #6DC692;
+  background-color: #6DC692 !important;
 }
 
 .wy-side-nav-search input[type=text]{
-  border-color: #6DC692;
+  border-color: #6DC692 !important;
 }

--- a/conf.py
+++ b/conf.py
@@ -117,11 +117,6 @@ if not on_rtd:
     html_style = 'css/cloudslang_theme.css'
 else:
     html_context = {
-        'css_files': [
-            'https://media.readthedocs.org/css/sphinx_rtd_theme.css',
-            'https://media.readthedocs.org/css/readthedocs-doc-embed.css',
-            '_static/css/cloudslang_theme.css',
-        ],
         'extra_css_files' : [
             '_static/css/cloudslang_theme.css'
         ]

--- a/conf.py
+++ b/conf.py
@@ -122,6 +122,9 @@ else:
             'https://media.readthedocs.org/css/readthedocs-doc-embed.css',
             '_static/css/cloudslang_theme.css',
         ],
+        'extra_css_files' : [
+            '_static/css/cloudslang_theme.css'
+        ]
     }
 
 # Theme options are theme-specific and customize the look and feel of a theme


### PR DESCRIPTION
Long story short(ish): the CloudSlang color disappeared from the docs because our custom CSS is now being imported before the other CSS files, thus rendering it useless. The only solution I found was this hack. Is this something we want to do, or is it too hacky?

As of now, all the versions are in RTD blue. We can change starting from v0.9 to CloudSlang green using this hack. (0.9 was already green, but turned back to blue when trying to figure out why the newer versions were blue. 0.8 is the old docs in Markdown and I don't think it pays to fool around with those and possibly break them.)
