### PR TITLE
Fix 05_lesson

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 site/
 _build/
 .idea/
+*.iml

--- a/tutorial/05_lesson.rst
+++ b/tutorial/05_lesson.rst
@@ -222,8 +222,6 @@ New Code - Complete
                 - address
             publish:
               - availability: ${available}
-            navigate:
-              - SUCCESS: SUCCESS
 
         - print_finish:
             do:


### PR DESCRIPTION
Closes: #300 

new_hire.sl step check_address contained an invalid navigate reference which caused the example flow to fail.

Signed-off-by: moldovso <sorin@hpe.com>