### PR TITLE
Fixing bugs in examples

### DIFF
--- a/cloudslang/cloudslang_examples.rst
+++ b/cloudslang/cloudslang_examples.rst
@@ -89,7 +89,7 @@ user-defined result of ``ILLEGAL``.
           if divisor == '0':
             quotient = 'division by zero error'
           else:
-            quotient = float(dividend) / float(divisor)
+            quotient = str(float(dividend) / float(divisor))
 
       outputs:
         - quotient
@@ -201,7 +201,7 @@ the success of its first step.
             print x
 
       results:
-        - FAILURE: ${x = 'important thing not done'}
+        - FAILURE: ${x == 'important thing not done'}
         - SUCCESS
 
 **Operation - send_email_mock.sl**
@@ -355,6 +355,25 @@ looped on and various methods for handling loop breaks.
                 - text: ${sum}
             navigate:
               - SUCCESS: SUCCESS
+
+**Operation - fail3.sl**
+
+.. code-block:: yaml
+
+    namespace: examples.loops
+
+    operation:
+      name: fail3
+
+      inputs:
+        - text
+
+      python_action:
+        script: print text
+
+      results:
+        - FAILURE: ${int(text) == 3}
+        - SUCCESS
 
 **Operation - custom3.sl**
 

--- a/tutorial/06_lesson.rst
+++ b/tutorial/06_lesson.rst
@@ -93,7 +93,7 @@ New Code - Complete
     
         - check_address:
             do:
-              hiring.check_availability:
+              check_availability:
                 - address
             publish:
               - availability: ${available}

--- a/tutorial/07_lesson.rst
+++ b/tutorial/07_lesson.rst
@@ -104,7 +104,7 @@ New Code - Complete
 
         - check_address:
             do:
-              hiring.check_availability:
+              check_availability:
                 - address
             publish:
               - availability: ${available}

--- a/tutorial/08_lesson.rst
+++ b/tutorial/08_lesson.rst
@@ -458,7 +458,7 @@ New Code - Complete
 
 .. code-block:: yaml
 
-    namespace: tutorials_08.hiring
+    namespace: tutorials.hiring
 
     operation:
       name: check_availability

--- a/tutorial/09_lesson.rst
+++ b/tutorial/09_lesson.rst
@@ -318,9 +318,9 @@ New Code - Complete
             do:
               check_availability:
                 - address
-                - password
             publish:
               - availability: ${available}
+              - password
             navigate:
               - UNAVAILABLE: UNAVAILABLE
               - AVAILABLE: CREATED

--- a/tutorial/11_lesson.rst
+++ b/tutorial/11_lesson.rst
@@ -302,7 +302,7 @@ New Code - Complete
           rand = random.randint(0, 2)
           available = rand != 0
           not_ordered = item + ';' if rand == 0 else ''
-          price = 0 if rand == 0 else price
+          spent = 0 if rand == 0 else price
           if rand == 0: print 'Unavailable'
 
       outputs:

--- a/tutorial/14_lesson.rst
+++ b/tutorial/14_lesson.rst
@@ -288,12 +288,12 @@ New Code - Complete
           if attempt == 1:
             address = first_name[0:1] + '.' + last_name + '@' + domain
           elif attempt == 2:
-            address = first_name + '.' + first_name[0:1] + '@' + domain
+            address = first_name + '.' + last_name[0:1] + '@' + domain
           elif attempt == 3 and middle_name != '':
             address = first_name + '.' + middle_name[0:1] + '.' + last_name + '@' + domain
           else:
             address = ''
-          #print address
+          # print address
 
       outputs:
         - email_address: ${address}


### PR DESCRIPTION
- Example 1 divide.sl: throws error about non-string value
- Example 2 something.sl: throws error
- Example 4: missing operation fail3
    Added operation similar to common3 but w/o custom navigation

Signed-off-by: Eckhart Beck <eckhart@eckhbeck.de>

Tried to get familiar with CloudSlang and tripped over the above mentioned errors/problems.
The errors occur at least with the current version of cslang-cli (1.0.19)